### PR TITLE
Added prompt persistence and initiator message

### DIFF
--- a/embellisher/commands/EmbellishCommand.ts
+++ b/embellisher/commands/EmbellishCommand.ts
@@ -3,6 +3,8 @@ import { ISlashCommand, SlashCommandContext } from "@rocket.chat/apps-engine/def
 import { sendNotification } from "../messages/sendNotification";
 import { EmbellisherApp } from "../EmbellisherApp";
 import { inference } from "../handlers/InferenceHandler";
+import { setResponse } from "../persistence/PromptPersistence";
+import { initiatorMessage } from "../messages/initiatorMessage";
 
 export class EmbellishCommand implements ISlashCommand {
 
@@ -41,8 +43,9 @@ export class EmbellishCommand implements ISlashCommand {
             default:
                 const user_text = context.getArguments().join(' ');
                 const response = await inference(this.app, user, room, modify, read, http, user_text);
+                await setResponse(context.getSender(), persistence, response);
                 const data = { user_text, response };
-                await sendNotification(user, room, modify, read, data.response);
+                await initiatorMessage(user, room, modify, data);
                 break;
         }
     }

--- a/embellisher/handlers/InferenceHandler.ts
+++ b/embellisher/handlers/InferenceHandler.ts
@@ -4,6 +4,7 @@ import { App } from '@rocket.chat/apps-engine/definition/App';
 import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { IRoom } from '@rocket.chat/apps-engine/definition/rooms';
 import { SystemPrompt } from '../config/SystemPrompt';
+import { getResponse } from '../persistence/PromptPersistence';
 
 export async function inference(
     app: App,
@@ -28,7 +29,7 @@ export async function inference(
 
     const delimiter = "<>"
     const instructs = "--"
-    const prev = "";
+    const prev = await getResponse(user, read.getPersistenceReader());
 
     const promptConfig = new SystemPrompt(
         redo,

--- a/embellisher/messages/initiatorMessage.ts
+++ b/embellisher/messages/initiatorMessage.ts
@@ -1,0 +1,50 @@
+import { IModify } from '@rocket.chat/apps-engine/definition/accessors';
+import { IRoom } from '@rocket.chat/apps-engine/definition/rooms';
+import { ButtonStyle } from '@rocket.chat/apps-engine/definition/uikit';
+import { IUser } from '@rocket.chat/apps-engine/definition/users';
+
+export async function initiatorMessage(
+    user: IUser,
+    room: IRoom,
+    modify: IModify,
+    data: any,
+): Promise<void> {
+
+    const builder = await modify.getCreator().startMessage().setRoom(room)
+    const block = modify.getCreator().getBlockBuilder();
+
+    block.addSectionBlock({
+        text: block.newMarkdownTextObject(`${data.response}`),
+    });
+
+    block.addActionsBlock({
+        blockId: "embellish",
+        elements: [
+            block.newButtonElement({
+                actionId: "copy",
+                text: block.newPlainTextObject("Copy"),
+            }),
+            block.newButtonElement({
+                actionId: "edit",
+                text: block.newPlainTextObject("Edit"),
+                value: data.response,
+                style: ButtonStyle.PRIMARY,
+            }),
+            block.newButtonElement({
+                actionId: "redo",
+                text: block.newPlainTextObject("Redo"),
+                value: data.user_text,
+                style: ButtonStyle.PRIMARY,
+            }),
+            block.newButtonElement({
+                actionId: "send",
+                text: block.newPlainTextObject("Send"),
+                value: data.response,
+                style: ButtonStyle.DANGER,
+            }),
+        ],
+    });
+
+    builder.setBlocks(block);
+    await modify.getNotifier().notifyUser(user, builder.getMessage());
+}

--- a/embellisher/persistence/PromptPersistence.ts
+++ b/embellisher/persistence/PromptPersistence.ts
@@ -1,0 +1,34 @@
+import { IPersistence, IPersistenceRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { RocketChatAssociationRecord, RocketChatAssociationModel } from "@rocket.chat/apps-engine/definition/metadata";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+
+export async function getResponse(user: IUser, persistence: IPersistenceRead): Promise<string> {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, 'message'),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, user.id),
+    ];
+
+    let result: Array<string> = [""];
+    const records: Array<{ response: string }> = (await persistence.readByAssociations(associations)) as Array<{ response: string }>;
+
+    if (records.length) {
+        result = records.map(({ response }) => response);
+    }
+
+    return result[0];
+}
+
+export async function setResponse(user: IUser, persistence: IPersistence, response: string): Promise<boolean> {
+    const associations: Array<RocketChatAssociationRecord> = [
+        new RocketChatAssociationRecord(RocketChatAssociationModel.MISC, 'message'),
+        new RocketChatAssociationRecord(RocketChatAssociationModel.USER, user.id),
+    ];
+
+    try {
+        await persistence.updateByAssociations(associations, { response }, true);
+    } catch (err) {
+        console.warn(err);
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
Added feature: #6 
- [x] Implemented prompt persistence to store LLM generated responses for LLM regeneration purposes.
- [x] Implemented initiator message to send interactive messages with copy, edit, redo and send button.