### PR TITLE
Added room interaction persistence and edit & redo modal

### DIFF
--- a/embellisher/modals/editModal.ts
+++ b/embellisher/modals/editModal.ts
@@ -1,0 +1,66 @@
+import { IModify, IPersistence, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { TextObjectType } from "@rocket.chat/apps-engine/definition/uikit";
+import { IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { getInteractionRoomData, storeInteractionRoomData } from "../persistence/RoomPersistence";
+
+export async function editModal(
+    value,
+    user: IUser,
+    room: IRoom | undefined,
+    read: IRead,
+    persistence: IPersistence,
+    modify: IModify,
+): Promise<IUIKitModalViewParam> {
+
+    let roomId;
+    const viewId = "edit-modal";
+    const block = modify.getCreator().getBlockBuilder();
+
+    if(room?.id) {
+        roomId = room.id
+        await storeInteractionRoomData(persistence, user.id, roomId);
+    } else {
+        roomId = (await getInteractionRoomData(read.getPersistenceReader(), user.id)).roomId;
+    }
+
+    block.addInputBlock({
+        blockId: "edit-block",
+        label: {
+            text: "Edit LLM Response",
+            type: TextObjectType.PLAINTEXT,
+        },
+
+        element: block.newPlainTextInputElement({
+            actionId: "editor",
+            placeholder: {
+                text: "Edit Here",
+                type: TextObjectType.PLAINTEXT,
+                emoji: true
+            },
+            initialValue: value,
+            multiline: true
+        }),
+    });
+
+    return {
+        id: viewId,
+        title: block.newPlainTextObject('Edit Response'),
+        close: block.newButtonElement({
+            text: {
+                type: TextObjectType.PLAINTEXT,
+                text: "Close",
+            },
+        }),
+        submit: block.newButtonElement({
+            actionId: "edited",
+            text: {
+                type: TextObjectType.PLAINTEXT,
+                text: "Send",
+            },
+        }),
+        blocks: block.getBlocks(),
+    };
+
+}

--- a/embellisher/modals/redoModal.ts
+++ b/embellisher/modals/redoModal.ts
@@ -1,0 +1,89 @@
+import { IModify, IPersistence, IRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { TextObjectType } from "@rocket.chat/apps-engine/definition/uikit";
+import { IUIKitModalViewParam } from "@rocket.chat/apps-engine/definition/uikit/UIKitInteractionResponder";
+import { IUser } from "@rocket.chat/apps-engine/definition/users";
+import { getResponse } from "../persistence/PromptPersistence";
+import { IRoom } from "@rocket.chat/apps-engine/definition/rooms";
+import { getInteractionRoomData, storeInteractionRoomData } from "../persistence/RoomPersistence";
+
+export async function redoModal(
+    value,
+    user: IUser,
+    room: IRoom | undefined,
+    read: IRead,
+    persistence: IPersistence,
+    modify: IModify,
+): Promise<IUIKitModalViewParam> {
+
+    let roomId;
+    const viewId = "redo-modal";
+    const response = await getResponse(user, read.getPersistenceReader());
+    const block = modify.getCreator().getBlockBuilder();
+
+    if(room?.id) {
+        roomId = room.id
+        await storeInteractionRoomData(persistence, user.id, roomId);
+    } else {
+        roomId = (await getInteractionRoomData(read.getPersistenceReader(), user.id)).roomId;
+    }
+
+    block.addSectionBlock({
+        text: { text: `*User Text* \n${value}`, type: TextObjectType.MARKDOWN, emoji: true},
+    });
+    block.addSectionBlock({
+        text: { text: `*LLM Response* \n${response}`, type: TextObjectType.MARKDOWN, emoji: true },
+    });
+
+    block.addDividerBlock();
+
+    block.addInputBlock({
+        blockId: "emoji-block",
+        label: {
+            text: "Emojification %",
+            type: TextObjectType.PLAINTEXT,
+        },
+        element: block.newPlainTextInputElement({
+            actionId: "emojify",
+            placeholder: {
+                text: "Enter emojification % (any number between 1 to 100%)",
+                type: TextObjectType.PLAINTEXT,
+            },
+            initialValue: "50",
+        }),
+    });
+
+    block.addInputBlock({
+        blockId: "instruct-block",
+        label: {
+           text: "Instruct Prompt",
+           type: TextObjectType.PLAINTEXT,
+        },
+        element: block.newPlainTextInputElement({
+            actionId: "instructions",
+            placeholder: {
+               text: "Enter modification instructions",
+               type: TextObjectType.PLAINTEXT,
+            }
+        }),
+    });
+
+    return {
+        id: viewId,
+        title: block.newPlainTextObject('Regenerate Response'),
+        close: block.newButtonElement({
+            text: {
+               type: TextObjectType.PLAINTEXT,
+               text: "Close",
+            },
+        }),
+        submit: block.newButtonElement({
+            actionId: "regenerate",
+            text: {
+               type: TextObjectType.PLAINTEXT,
+               text: "Regenerate",
+            },
+        }),
+        blocks: block.getBlocks(),
+    };
+
+}

--- a/embellisher/persistence/RoomPersistence.ts
+++ b/embellisher/persistence/RoomPersistence.ts
@@ -1,0 +1,39 @@
+import { IPersistence, IPersistenceRead } from "@rocket.chat/apps-engine/definition/accessors";
+import { RocketChatAssociationRecord, RocketChatAssociationModel } from "@rocket.chat/apps-engine/definition/metadata";
+
+export async function storeInteractionRoomData(
+    persistence: IPersistence,
+    userId: string,
+    roomId: string
+): Promise<void> {
+    const association = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.USER,
+        `${userId}#RoomId`
+    );
+    await persistence.updateByAssociation(association, { roomId: roomId }, true);
+};
+
+
+export async function getInteractionRoomData(
+    persistenceRead: IPersistenceRead,
+    userId: string
+): Promise<any> {
+    const association = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.USER,
+        `${userId}#RoomId`
+    );
+    const result = (await persistenceRead.readByAssociation(association)) as Array<any>;
+    return result && result.length ? result[0] : null;
+};
+
+
+export async function clearInteractionRoomData(
+    persistence: IPersistence,
+    userId: string
+): Promise<void> {
+    const association = new RocketChatAssociationRecord(
+        RocketChatAssociationModel.USER,
+        `${userId}#RoomId`
+    );
+    await persistence.removeByAssociation(association);
+};


### PR DESCRIPTION
Added feature: #9 
- [x] Implemented room persistence to store and retrieve room ids for modal view submit actions.
- [x] Implemented edit and redo modals for editing and regenerating response.